### PR TITLE
Fix actuator payload message type in python3.

### DIFF
--- a/devicehub/devicehub.py
+++ b/devicehub/devicehub.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+from __future__ import print_function
+
 import paho.mqtt.client as mqtt
 from time import sleep, time
 from datetime import datetime
@@ -407,7 +409,7 @@ class Actuator(object):
         self.callback = None
 
     def default_callback(self, *args):
-        message = args[2].payload
+        message = args[2].payload.decode()
 
         try:
             payload = json.loads(message)


### PR DESCRIPTION
In Python3, the MQTT message payload is a bytes literal, not string, and json.loads() specifically accepts only strings.

The change does not affect python2, since a regular string decoded turn into an unicode string that handles the same under json.loads().